### PR TITLE
 Fix documentation heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Container 2
 
 <br>
 <a id="Components-Categories"></a>
+
 # Components Categories
 
 


### PR DESCRIPTION
Fix ` # Components Categories` not being formatted correctly